### PR TITLE
feat: implement habit CRUD interface with form and listing

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -1,48 +1,34 @@
-# Database Schema Setup
+# Database Setup
 
-This directory contains the database schema files for the Habit Flow application.
+This directory contains SQL scripts for setting up the Habit Flow database schema.
 
 ## Setup Instructions
 
-### 1. Supabase Database Setup
+1. **Profiles Schema** (already set up):
+   ```sql
+   -- Run this first to set up user profiles
+   \i profiles_schema.sql
+   ```
 
-1. Go to your Supabase dashboard
-2. Navigate to the SQL Editor
-3. Run the `profiles_schema.sql` file to create the profiles table and necessary policies
+2. **Habits Schema** (new):
+   ```sql
+   -- Run this to set up the habits table
+   \i habits_schema.sql
+   ```
 
-### 2. What the Schema Includes
+## Database Tables
 
-- **profiles table**: Stores user profile information
-- **Storage bucket**: For avatar uploads
-- **Row Level Security (RLS)**: Ensures users can only access their own data
-- **Triggers**: Automatically creates profile when user signs up and updates timestamps
+### profiles
+- User profile information
+- Linked to auth.users via foreign key
+- Includes notification preferences
 
-### 3. Table Structure
+### habits
+- User habits with title, description, and frequency
+- Linked to auth.users via user_id foreign key
+- Supports daily, weekly, and monthly frequencies
+- Row Level Security (RLS) enabled for data isolation
 
-```sql
-profiles (
-  id UUID PRIMARY KEY,           -- References auth.users(id)
-  email TEXT NOT NULL,           -- User's email
-  first_name TEXT,               -- User's first name
-  last_name TEXT,                -- User's last name
-  phone TEXT,                    -- User's phone number
-  avatar_url TEXT,               -- URL to user's avatar image
-  email_notifications BOOLEAN,   -- Email notification preference
-  daily_reminders BOOLEAN,       -- Daily reminder preference
-  weekly_reports BOOLEAN,        -- Weekly report preference
-  created_at TIMESTAMP,          -- Record creation timestamp
-  updated_at TIMESTAMP           -- Record update timestamp
-)
-```
+## Security
 
-### 4. Storage Bucket
-
-- **Bucket name**: `avatars`
-- **Public access**: Yes (for viewing avatars)
-- **Path structure**: `avatars/{user_id}-{timestamp}.{extension}`
-
-### 5. Security Policies
-
-- Users can only view, insert, and update their own profile
-- Users can upload, view, update, and delete their own avatars
-- All avatar images are publicly viewable (but only the owner can modify)
+All tables use Row Level Security (RLS) to ensure users can only access their own data. The policies are automatically applied when the schema scripts are run.

--- a/database/habits_schema.sql
+++ b/database/habits_schema.sql
@@ -1,0 +1,55 @@
+-- Create habits table
+CREATE TABLE IF NOT EXISTS habits (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT,
+  frequency TEXT NOT NULL CHECK (frequency IN ('daily', 'weekly', 'monthly')),
+  is_active BOOLEAN DEFAULT true,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Set up Row Level Security (RLS)
+ALTER TABLE habits ENABLE ROW LEVEL SECURITY;
+
+-- Drop existing policies if they exist (to avoid conflicts)
+DROP POLICY IF EXISTS "Users can view their own habits" ON habits;
+DROP POLICY IF EXISTS "Users can update their own habits" ON habits;
+DROP POLICY IF EXISTS "Users can insert their own habits" ON habits;
+DROP POLICY IF EXISTS "Users can delete their own habits" ON habits;
+
+-- Create policies
+CREATE POLICY "Users can view their own habits" ON habits
+  FOR SELECT USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can update their own habits" ON habits
+  FOR UPDATE USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can insert their own habits" ON habits
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete their own habits" ON habits
+  FOR DELETE USING (auth.uid() = user_id);
+
+-- Create function to handle updated_at timestamp
+CREATE OR REPLACE FUNCTION handle_habits_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Drop existing trigger if it exists
+DROP TRIGGER IF EXISTS habits_updated_at ON habits;
+
+-- Create trigger for updated_at
+CREATE TRIGGER habits_updated_at
+  BEFORE UPDATE ON habits
+  FOR EACH ROW
+  EXECUTE FUNCTION handle_habits_updated_at();
+
+-- Create index for better performance
+CREATE INDEX IF NOT EXISTS idx_habits_user_id ON habits(user_id);
+CREATE INDEX IF NOT EXISTS idx_habits_is_active ON habits(is_active);

--- a/src/components/habits/HabitForm.vue
+++ b/src/components/habits/HabitForm.vue
@@ -1,0 +1,256 @@
+<template>
+  <div class="bg-white rounded-lg shadow p-6">
+    <div class="flex justify-between items-center mb-6">
+      <h2 class="text-xl font-semibold text-gray-900">
+        {{ isEditing ? 'Edit Habit' : 'Add New Habit' }}
+      </h2>
+      <button
+        v-if="isEditing"
+        @click="$emit('cancel')"
+        class="text-gray-400 hover:text-gray-600 transition-colors"
+      >
+        <svg
+          class="w-6 h-6"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M6 18L18 6M6 6l12 12"
+          ></path>
+        </svg>
+      </button>
+    </div>
+
+    <form @submit.prevent="handleSubmit" class="space-y-4">
+      <!-- Title Field -->
+      <div>
+        <label for="title" class="block text-sm font-medium text-gray-700 mb-1">
+          Title *
+        </label>
+        <input
+          id="title"
+          v-model="form.title"
+          type="text"
+          required
+          class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          placeholder="Enter habit title"
+          :disabled="loading"
+        />
+      </div>
+
+      <!-- Description Field -->
+      <div>
+        <label
+          for="description"
+          class="block text-sm font-medium text-gray-700 mb-1"
+        >
+          Description
+        </label>
+        <textarea
+          id="description"
+          v-model="form.description"
+          rows="3"
+          class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          placeholder="Describe your habit"
+          :disabled="loading"
+        ></textarea>
+      </div>
+
+      <!-- Frequency Field -->
+      <div>
+        <label
+          for="frequency"
+          class="block text-sm font-medium text-gray-700 mb-1"
+        >
+          Frequency *
+        </label>
+        <select
+          id="frequency"
+          v-model="form.frequency"
+          required
+          class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          :disabled="loading"
+        >
+          <option value="daily">Daily</option>
+          <option value="weekly">Weekly</option>
+          <option value="monthly">Monthly</option>
+        </select>
+      </div>
+
+      <!-- Error Message -->
+      <div v-if="error" class="bg-red-50 border border-red-200 rounded-md p-3">
+        <p class="text-sm text-red-600">{{ error }}</p>
+      </div>
+
+      <!-- Submit Button -->
+      <div class="flex justify-end space-x-3">
+        <button
+          v-if="isEditing"
+          type="button"
+          @click="$emit('cancel')"
+          class="px-4 py-2 text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 transition-colors"
+          :disabled="loading"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          :disabled="loading || !form.title.trim()"
+        >
+          <span v-if="loading" class="flex items-center">
+            <svg
+              class="animate-spin -ml-1 mr-2 h-4 w-4 text-white"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                class="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                stroke-width="4"
+              ></circle>
+              <path
+                class="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              ></path>
+            </svg>
+            {{ isEditing ? 'Updating...' : 'Creating...' }}
+          </span>
+          <span v-else>
+            {{ isEditing ? 'Update Habit' : 'Create Habit' }}
+          </span>
+        </button>
+      </div>
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, onMounted } from 'vue';
+import {
+  useHabitsStore,
+  type CreateHabitData,
+  type UpdateHabitData,
+  type Habit,
+} from '@/store/habits';
+
+interface Props {
+  habit?: Habit | null;
+  isEditing?: boolean;
+}
+
+interface Emits {
+  (e: 'success'): void;
+  (e: 'cancel'): void;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  habit: null,
+  isEditing: false,
+});
+
+const emit = defineEmits<Emits>();
+
+const habitsStore = useHabitsStore();
+
+const form = ref<CreateHabitData>({
+  title: '',
+  description: '',
+  frequency: 'daily',
+});
+
+const loading = ref(false);
+const error = ref<string | null>(null);
+
+// Watch for habit changes when editing
+watch(
+  () => props.habit,
+  newHabit => {
+    if (newHabit && props.isEditing) {
+      form.value = {
+        title: newHabit.title,
+        description: newHabit.description,
+        frequency: newHabit.frequency,
+      };
+    }
+  },
+  { immediate: true }
+);
+
+// Reset form when switching from edit to create mode
+watch(
+  () => props.isEditing,
+  isEditing => {
+    if (!isEditing) {
+      resetForm();
+    }
+  }
+);
+
+const resetForm = () => {
+  form.value = {
+    title: '',
+    description: '',
+    frequency: 'daily',
+  };
+  error.value = null;
+};
+
+const handleSubmit = async () => {
+  if (!form.value.title.trim()) {
+    error.value = 'Title is required';
+    return;
+  }
+
+  loading.value = true;
+  error.value = null;
+
+  try {
+    if (props.isEditing && props.habit) {
+      const updateData: UpdateHabitData = {
+        title: form.value.title,
+        description: form.value.description,
+        frequency: form.value.frequency,
+      };
+
+      const result = await habitsStore.updateHabit(props.habit.id, updateData);
+      if (!result.success) {
+        error.value = result.error || 'Failed to update habit';
+        return;
+      }
+    } else {
+      const result = await habitsStore.createHabit(form.value);
+      if (!result.success) {
+        error.value = result.error || 'Failed to create habit';
+        return;
+      }
+    }
+
+    resetForm();
+    emit('success');
+  } catch (err) {
+    error.value =
+      err instanceof Error ? err.message : 'An unexpected error occurred';
+  } finally {
+    loading.value = false;
+  }
+};
+
+onMounted(() => {
+  if (props.habit && props.isEditing) {
+    form.value = {
+      title: props.habit.title,
+      description: props.habit.description,
+      frequency: props.habit.frequency,
+    };
+  }
+});
+</script>

--- a/src/components/habits/HabitList.vue
+++ b/src/components/habits/HabitList.vue
@@ -1,0 +1,183 @@
+<template>
+  <div>
+    <!-- Loading State -->
+    <div
+      v-if="loading && habits.length === 0"
+      class="flex justify-center items-center py-12"
+    >
+      <div
+        class="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"
+      ></div>
+    </div>
+
+    <!-- Empty State -->
+    <div v-else-if="habits.length === 0" class="text-center py-12">
+      <svg
+        class="mx-auto h-12 w-12 text-gray-400"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"
+        ></path>
+      </svg>
+      <h3 class="mt-2 text-sm font-medium text-gray-900">No habits yet</h3>
+      <p class="mt-1 text-sm text-gray-500">
+        Get started by creating your first habit.
+      </p>
+    </div>
+
+    <!-- Habits Grid -->
+    <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div
+        v-for="habit in habits"
+        :key="habit.id"
+        class="bg-white rounded-lg shadow p-6 hover:shadow-md transition-shadow"
+      >
+        <!-- Header -->
+        <div class="flex items-center justify-between mb-4">
+          <h3 class="text-lg font-semibold text-gray-900">{{ habit.title }}</h3>
+          <span
+            :class="[
+              'px-2 py-1 text-xs rounded-full',
+              habit.is_active
+                ? 'bg-green-100 text-green-800'
+                : 'bg-gray-100 text-gray-800',
+            ]"
+          >
+            {{ habit.is_active ? 'Active' : 'Inactive' }}
+          </span>
+        </div>
+
+        <!-- Description -->
+        <p v-if="habit.description" class="text-gray-600 mb-4">
+          {{ habit.description }}
+        </p>
+
+        <!-- Frequency Badge -->
+        <div class="mb-4">
+          <span
+            class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800"
+          >
+            {{ formatFrequency(habit.frequency) }}
+          </span>
+        </div>
+
+        <!-- Actions -->
+        <div class="flex items-center justify-between">
+          <div class="flex space-x-2">
+            <button
+              @click="handleEdit(habit)"
+              class="text-blue-600 hover:text-blue-700 text-sm font-medium transition-colors"
+              :disabled="loading"
+            >
+              Edit
+            </button>
+            <button
+              @click="handleToggleStatus(habit)"
+              class="text-green-600 hover:text-green-700 text-sm font-medium transition-colors"
+              :disabled="loading"
+            >
+              {{ habit.is_active ? 'Pause' : 'Resume' }}
+            </button>
+            <button
+              @click="handleDelete(habit)"
+              class="text-red-600 hover:text-red-700 text-sm font-medium transition-colors"
+              :disabled="loading"
+            >
+              Delete
+            </button>
+          </div>
+        </div>
+
+        <!-- Created Date -->
+        <div class="mt-4 pt-4 border-t border-gray-100">
+          <p class="text-xs text-gray-500">
+            Created {{ formatDate(habit.created_at) }}
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Error Message -->
+    <div
+      v-if="error"
+      class="mt-4 bg-red-50 border border-red-200 rounded-md p-3"
+    >
+      <p class="text-sm text-red-600">{{ error }}</p>
+      <button
+        @click="clearError"
+        class="mt-2 text-sm text-red-600 hover:text-red-700 underline"
+      >
+        Dismiss
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useHabitsStore, type Habit } from '@/store/habits';
+
+interface Emits {
+  (e: 'edit', habit: Habit): void;
+}
+
+const emit = defineEmits<Emits>();
+
+const habitsStore = useHabitsStore();
+
+const habits = computed(() => habitsStore.habits);
+const loading = computed(() => habitsStore.loading);
+const error = computed(() => habitsStore.error);
+
+const formatFrequency = (frequency: string) => {
+  const frequencyMap = {
+    daily: 'Daily',
+    weekly: 'Weekly',
+    monthly: 'Monthly',
+  };
+  return frequencyMap[frequency as keyof typeof frequencyMap] || frequency;
+};
+
+const formatDate = (dateString: string) => {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+};
+
+const handleEdit = (habit: Habit) => {
+  emit('edit', habit);
+};
+
+const handleToggleStatus = async (habit: Habit) => {
+  const result = await habitsStore.toggleHabitStatus(habit.id);
+  if (!result.success) {
+    console.error('Failed to toggle habit status:', result.error);
+  }
+};
+
+const handleDelete = async (habit: Habit) => {
+  if (
+    window.confirm(
+      `Are you sure you want to delete "${habit.title}"? This action cannot be undone.`
+    )
+  ) {
+    const result = await habitsStore.deleteHabit(habit.id);
+    if (!result.success) {
+      console.error('Failed to delete habit:', result.error);
+    }
+  }
+};
+
+const clearError = () => {
+  habitsStore.clearError();
+};
+</script>

--- a/src/store/habits.ts
+++ b/src/store/habits.ts
@@ -1,0 +1,206 @@
+import { defineStore } from 'pinia';
+import { ref, computed } from 'vue';
+import { supabase } from '../lib/supabase';
+
+export interface Habit {
+  id: string;
+  user_id: string;
+  title: string;
+  description: string;
+  frequency: 'daily' | 'weekly' | 'monthly';
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateHabitData {
+  title: string;
+  description: string;
+  frequency: 'daily' | 'weekly' | 'monthly';
+}
+
+export interface UpdateHabitData {
+  title?: string;
+  description?: string;
+  frequency?: 'daily' | 'weekly' | 'monthly';
+  is_active?: boolean;
+}
+
+export const useHabitsStore = defineStore('habits', () => {
+  const habits = ref<Habit[]>([]);
+  const loading = ref(false);
+  const error = ref<string | null>(null);
+
+  const activeHabits = computed(() =>
+    habits.value.filter(habit => habit.is_active)
+  );
+
+  const inactiveHabits = computed(() =>
+    habits.value.filter(habit => !habit.is_active)
+  );
+
+  // Fetch all habits for the current user
+  const fetchHabits = async () => {
+    try {
+      loading.value = true;
+      error.value = null;
+
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) {
+        throw new Error('User not authenticated');
+      }
+
+      const { data, error: fetchError } = await supabase
+        .from('habits')
+        .select('*')
+        .eq('user_id', user.id)
+        .order('created_at', { ascending: false });
+
+      if (fetchError) {
+        throw fetchError;
+      }
+
+      habits.value = data || [];
+      return { success: true, data };
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : 'Failed to fetch habits';
+      error.value = errorMessage;
+      return { success: false, error: errorMessage };
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  // Create a new habit
+  const createHabit = async (habitData: CreateHabitData) => {
+    try {
+      loading.value = true;
+      error.value = null;
+
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) {
+        throw new Error('User not authenticated');
+      }
+
+      const { data, error: createError } = await supabase
+        .from('habits')
+        .insert({
+          user_id: user.id,
+          title: habitData.title,
+          description: habitData.description,
+          frequency: habitData.frequency,
+          is_active: true,
+        })
+        .select()
+        .single();
+
+      if (createError) {
+        throw createError;
+      }
+
+      habits.value.unshift(data);
+      return { success: true, data };
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : 'Failed to create habit';
+      error.value = errorMessage;
+      return { success: false, error: errorMessage };
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  // Update an existing habit
+  const updateHabit = async (habitId: string, updates: UpdateHabitData) => {
+    try {
+      loading.value = true;
+      error.value = null;
+
+      const { data, error: updateError } = await supabase
+        .from('habits')
+        .update(updates)
+        .eq('id', habitId)
+        .select()
+        .single();
+
+      if (updateError) {
+        throw updateError;
+      }
+
+      const index = habits.value.findIndex(habit => habit.id === habitId);
+      if (index !== -1) {
+        habits.value[index] = data;
+      }
+
+      return { success: true, data };
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : 'Failed to update habit';
+      error.value = errorMessage;
+      return { success: false, error: errorMessage };
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  // Delete a habit
+  const deleteHabit = async (habitId: string) => {
+    try {
+      loading.value = true;
+      error.value = null;
+
+      const { error: deleteError } = await supabase
+        .from('habits')
+        .delete()
+        .eq('id', habitId);
+
+      if (deleteError) {
+        throw deleteError;
+      }
+
+      habits.value = habits.value.filter(habit => habit.id !== habitId);
+      return { success: true };
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : 'Failed to delete habit';
+      error.value = errorMessage;
+      return { success: false, error: errorMessage };
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  // Toggle habit active status
+  const toggleHabitStatus = async (habitId: string) => {
+    const habit = habits.value.find(h => h.id === habitId);
+    if (!habit) {
+      return { success: false, error: 'Habit not found' };
+    }
+
+    return await updateHabit(habitId, { is_active: !habit.is_active });
+  };
+
+  // Clear error
+  const clearError = () => {
+    error.value = null;
+  };
+
+  return {
+    habits,
+    loading,
+    error,
+    activeHabits,
+    inactiveHabits,
+    fetchHabits,
+    createHabit,
+    updateHabit,
+    deleteHabit,
+    toggleHabitStatus,
+    clearError,
+  };
+});

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -7,3 +7,4 @@ export const pinia = createPinia();
 export * from './demo';
 export * from './auth';
 export * from './profile';
+export * from './habits';

--- a/src/views/Habits.vue
+++ b/src/views/Habits.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
+    <!-- Header -->
     <div class="mb-8">
       <div class="flex justify-between items-center">
         <div>
@@ -9,6 +10,8 @@
           </p>
         </div>
         <button
+          v-if="!showForm"
+          @click="showAddForm"
           class="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors"
         >
           Add Habit
@@ -16,66 +19,78 @@
       </div>
     </div>
 
-    <!-- Habits grid -->
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-      <div class="bg-white rounded-lg shadow p-6">
-        <div class="flex items-center justify-between mb-4">
-          <h3 class="text-lg font-semibold text-gray-900">Morning Exercise</h3>
-          <span
-            class="px-2 py-1 bg-green-100 text-green-800 text-xs rounded-full"
-            >Active</span
-          >
-        </div>
-        <p class="text-gray-600 mb-4">
-          30 minutes of cardio or strength training
-        </p>
-        <div class="flex items-center justify-between">
-          <span class="text-sm text-gray-500">7 day streak</span>
-          <button class="text-blue-600 hover:text-blue-700 text-sm font-medium">
-            Mark Complete
-          </button>
-        </div>
-      </div>
+    <!-- Habit Form -->
+    <div v-if="showForm" class="mb-8">
+      <HabitForm
+        :habit="editingHabit"
+        :is-editing="!!editingHabit"
+        @success="handleFormSuccess"
+        @cancel="handleFormCancel"
+      />
+    </div>
 
-      <div class="bg-white rounded-lg shadow p-6">
-        <div class="flex items-center justify-between mb-4">
-          <h3 class="text-lg font-semibold text-gray-900">
-            Read for 30 minutes
-          </h3>
-          <span
-            class="px-2 py-1 bg-green-100 text-green-800 text-xs rounded-full"
-            >Active</span
-          >
-        </div>
-        <p class="text-gray-600 mb-4">Daily reading to expand knowledge</p>
-        <div class="flex items-center justify-between">
-          <span class="text-sm text-gray-500">3 day streak</span>
-          <button class="text-blue-600 hover:text-blue-700 text-sm font-medium">
-            Mark Complete
-          </button>
-        </div>
-      </div>
+    <!-- Habit List -->
+    <HabitList @edit="handleEditHabit" />
 
-      <div class="bg-white rounded-lg shadow p-6">
-        <div class="flex items-center justify-between mb-4">
-          <h3 class="text-lg font-semibold text-gray-900">Meditation</h3>
-          <span
-            class="px-2 py-1 bg-yellow-100 text-yellow-800 text-xs rounded-full"
-            >Paused</span
-          >
-        </div>
-        <p class="text-gray-600 mb-4">10 minutes of mindfulness practice</p>
-        <div class="flex items-center justify-between">
-          <span class="text-sm text-gray-500">0 day streak</span>
-          <button class="text-blue-600 hover:text-blue-700 text-sm font-medium">
-            Resume
-          </button>
-        </div>
+    <!-- Loading Overlay -->
+    <div
+      v-if="loading"
+      class="fixed inset-0 bg-black bg-opacity-25 flex items-center justify-center z-50"
+    >
+      <div class="bg-white rounded-lg p-6 flex items-center space-x-3">
+        <div
+          class="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600"
+        ></div>
+        <span class="text-gray-700">Loading habits...</span>
       </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-// Habits component logic will go here
+import { ref, onMounted } from 'vue';
+import { useHabitsStore, type Habit } from '@/store/habits';
+import HabitForm from '@/components/habits/HabitForm.vue';
+import HabitList from '@/components/habits/HabitList.vue';
+
+const habitsStore = useHabitsStore();
+
+const showForm = ref(false);
+const editingHabit = ref<Habit | null>(null);
+const loading = ref(false);
+
+const showAddForm = () => {
+  editingHabit.value = null;
+  showForm.value = true;
+};
+
+const handleEditHabit = (habit: Habit) => {
+  editingHabit.value = habit;
+  showForm.value = true;
+};
+
+const handleFormSuccess = () => {
+  showForm.value = false;
+  editingHabit.value = null;
+};
+
+const handleFormCancel = () => {
+  showForm.value = false;
+  editingHabit.value = null;
+};
+
+const loadHabits = async () => {
+  loading.value = true;
+  try {
+    await habitsStore.fetchHabits();
+  } catch (error) {
+    console.error('Failed to load habits:', error);
+  } finally {
+    loading.value = false;
+  }
+};
+
+onMounted(() => {
+  loadHabits();
+});
 </script>


### PR DESCRIPTION
- Add habits store with full CRUD operations (create, read, update, delete)
- Create HabitForm component with title, description, and frequency fields
- Create HabitList component with edit/delete options and status toggle
- Update Habits.vue to integrate form and list components
- Add database schema for habits table with RLS policies
- Support daily, weekly, and monthly frequency options
- Include proper error handling and loading states
- Add TypeScript interfaces for type safety

Closes #9